### PR TITLE
[APP-4023] Add shell flag

### DIFF
--- a/src/build-app.sh
+++ b/src/build-app.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
-
+# It's important to fail the build if a command such as `npm install` fails. 
+set -e
 if [ -f "package.json" ]; then
     echo "Installing Node.js dependencies from package.json..."
     npm install


### PR DESCRIPTION
We have had issues before where an app build should fail (because a package wasn't available) but the build is marked as passing and the app fails to start. This can lead to confusion. 
More broadly any script with the format:
```
<passing commands>
<failing command>
<passing commands>
```
will have a successful exit code and lead the app developer to think their build was a success. Commands like:
```
<passing commands>
<failing command>
```
will mark the build as failed. This is an implementation detail of shell specifically, and not every build-app will use shell. We can easily imagine a build-app with:
``` python
#!/usr/bin/env python
import ... 
if __name__=='__main__':
    do_stuff()
```

So, the smallest change we can do to remind users about this caveat is to just have it in the examples. 